### PR TITLE
Quay build and Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,28 @@
 
 This is a Dockerfile that launches a StriderCD server configured to easily run page builds. There are other Strider Dockerfiles, but many of them (including the quasi-official one) bundle MongoDB, which feels like overkill.
 
-To build and run this container, you must have access to a MongoDB as mentioned above.  If you have mongod running on your localhost, you can pass in the database string as an environment variable.  Starting from the root directory of this GitHub project:
+## Running Strider locally
 
+To build and run this container, you'll first need to install:
+
+ * [Docker](https://docs.docker.com/installation/#installation) to build and launch the container.
+ * [docker-compose](https://docs.docker.com/compose/install/) to manage the container's configuration.
+
+Now invoke docker-compose:
+
+```bash
+# Rebuild the image
+docker-compose build
+
+# Launch the strider and MongoDB containers as daemons.
+docker-compose up -d
 ```
-$ docker build -t="strider" .
-$ docker run -p 3000:3000 -d -e "DB_URI=mongodb://192.168.59.3/strider" --name strider
-```
 
-Note: your IP address may differ. If you are running docker from Linux, it should be your localhost. If you are running boot2docker, you can find your ip by running ```boot2docker config | grep HostIP```  Also, if you have a username and password setup for mongo, you can set your connection string to DB_URI=mongodb://user:password@192.168.59.3/strider
+Strider is now running and connected to a MongoDB database running in another container. However, you won't be able to log in yet, because you don't have an admin user! To create one, follow the prompts when you run:
 
-From here, you have a container running strider, connected to the database you specified.  You should be able to connect to it with your web browser.  Hint: Remember if you are using boot2docker that you must connect to your Linux VM's IP address, which can be found with ```boot2docker ip```
-
-Unfortunately, if this is your first time running strider, that database has probably not been seeded with the admin user.  To seed your database, you can do this:
-
-```
-$ docker exec -t -i strider /bin/bash
-strider@9e16ad168acf:~$ node /home/strider/node_modules/.bin/strider addUser
-Connecting to MongoDB URL: mongodb://192.168.59.3/strider
+```bash
+$ script/admin-user
+Connecting to MongoDB URL: mongodb://mongo/strider
 
 Enter email []: your-email@your-org.com
 Is admin? (y/n) [n]y
@@ -29,14 +34,11 @@ Enter password []: ****
 Email:		your-email@your-org.com
 Password:	****
 isAdmin:	y
-OK? (y/n) [y]y
+OK? (y/n) [y]
 
 User added successfully! Enjoy.
-strider@00000ca92151:~$ exit
 ```
 
-Now you should be able to login to your strider instance with the email address and password you setup.
+Visit port 3000 on the appropriate host to log in. :sparkles:
 
-TODO: we need a better way to initialize the database.
-
-This Dockerfile is also available from Docker Hub here: https://registry.hub.docker.com/u/deconst/strider/
+**Note:** If you're running Docker through boot2docker or docker-machine (on a Mac or Windows), the URL you'll use to connect will *not* be http://localhost:3000/. You'll need to locate the IP address of the boot2docker VM with `boot2docker ip` and connect to port 3000 on that host instead.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Strider
 
+[![Docker Repository on Quay.io](https://quay.io/repository/deconst/strider/status "Docker Repository on Quay.io")](https://quay.io/repository/deconst/strider)
+
 This is a Dockerfile that launches a StriderCD server configured to easily run page builds. There are other Strider Dockerfiles, but many of them (including the quasi-official one) bundle MongoDB, which feels like overkill.
 
 To build and run this container, you must have access to a MongoDB as mentioned above.  If you have mongod running on your localhost, you can pass in the database string as an environment variable.  Starting from the root directory of this GitHub project:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+---
+mongo:
+  image: mongodb:2.6
+strider:
+  build: .
+  links:
+  - "mongo:mongo"
+  ports:
+  - "3000:3000"
+  environment:
+    DB_URI: "mongodb://mongo/strider"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 ---
 mongo:
-  image: mongodb:2.6
+  image: mongo:3.0
 strider:
   build: .
   links:

--- a/script/admin-user
+++ b/script/admin-user
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# Seed Strider with an admin user.
+
+set -euo pipefail
+
+SUDO='sudo'
+which boot2docker >/dev/null 2>&1 && SUDO=''
+
+${SUDO} docker-compose run --rm strider addUser


### PR DESCRIPTION
Include the quay.io build badge. Use docker-compose for local building and execution, which simplifies things _a lot_.
